### PR TITLE
Fix ansible provisioning so this repo actually works with latest version of StackStorm

### DIFF
--- a/ansible/roles/st2_dev/tasks/mongo.yml
+++ b/ansible/roles/st2_dev/tasks/mongo.yml
@@ -2,14 +2,14 @@
 - name: Add mongo ppa key
   become: yes
   apt_key:
-    url: https://www.mongodb.org/static/pgp/server-3.4.asc
+    url: https://www.mongodb.org/static/pgp/server-4.0.asc
     state: present
 - name: Add mongo sources list
   become: yes
   copy:
     dest: /etc/apt/sources.list.d/mongodb.list
     content: >
-        deb https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse
+        deb https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.0 multiverse
 - name: Install mongo
   become: yes
   apt:

--- a/ansible/roles/st2_dev/tasks/python.yml
+++ b/ansible/roles/st2_dev/tasks/python.yml
@@ -1,13 +1,30 @@
 ---
+- name: Add source repository into sources list
+  become: true
+  ansible.builtin.apt_repository:
+    update_cache: true
+    repo: ppa:deadsnakes/ppa
+    state: present
 - name: Install python system dependencies
   become: true
   apt:
     state: latest
     name:
-      - python-pip
-      - python-dev
-      - python-setuptools
-- name: Install global python dependencies
-  pip:
-    name:
-      - virtualenv
+      - python3.6
+      - python3.6-dev
+      - python3.6-venv
+      # Needed for python ldap package
+      - libsasl2-dev
+      - libldap2-dev
+      - libssl-dev
+- name: Install pip
+  become: true
+  ansible.builtin.shell: curl https://bootstrap.pypa.io/get-pip.py | sudo python3.6
+- name: Install virtualenv
+  become: true
+  ansible.builtin.shell: python3.6 -m pip install virtualenv
+- name: Set python3.6 as default python 3
+  become: true
+  ansible.builtin.shell: |
+    sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
+    sudo update-alternatives --set python3 /usr/bin/python3.6


### PR DESCRIPTION
This pull request includes the following changes to get this image working with latest version of StackStorm:

- Install Python 3.6 and make it a default python3 interpreter (all StackStorm deps don't work with python3.5)
- Install MongoDB 4.0 instead of ancient 3.4
- Add missing libraries which are needed for ``make requirements`` to work

I confirmed that with those changes launchdev scriptvi, lint, unit-tests and other make tasks work.