### PR TITLE
Update ansible step to also generate and configure stanley ssh key

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,22 @@ For more information, please refer to https://docs.stackstorm.com/install/vagran
 
 To quickly get bootstrapped run the following:
 
-1. Clone repo
-2. Execute `vagrant up` inside repo
-3. Execute `vagrant ssh` inside repo
-4. Execute `cd ~/local/st2` inside virtual machine
-5. Execute `make requirements` inside `~/local/st2`
-6. Execute `source virtualenv/bin/activate` inside `~/local/st2`
-7. Execute `make cli` inside `~/local/st2`
-8. Execute `./tools/launchdev.sh start -x` inside `~/local/st2`
+1. Clone your StackStorm/st2 git repo fork which you will use to develop and test on to ../st2
+   (``git clone https://github.com/StackStorm/st2.git ../st2``)
+2. Clone this repo
+3. Execute `vagrant up` inside repo
+4. Execute `vagrant ssh` inside repo
+5. Execute `cd ~/local/st2` inside virtual machine
+6. Execute `make requirements` inside `~/local/st2`
+7. Execute `source virtualenv/bin/activate` inside `~/local/st2`
+8. Execute `make cli` inside `~/local/st2`
+9. Execute `./tools/launchdev.sh start -x` inside `~/local/st2`
 
 You will likely from here want to share your local `st2` repo with the vagrant image to migrate code 
 more quickly. To sync your changes execute `vagrant rsync` from within this repo. `vagrant rsync` command 
 assumes that the local `st2` repo is accessible as `../st2`. 
+
+As an alternative (per example in Vagrantfile), you can also use nfs mount where changes are
+automatically reflected inside the virtual machine immediately after you make them on host.
 
 Note: Make sure to run step 5 (`make requirements`) inside `~/local/st2` instead of `~/st2` to have the `PYTHONPATH` point to the modules inside `~/st2/local/st2`.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,5 +17,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.synced_folder "../st2", "/home/vagrant/local/st2", type: "rsync", rsync__exclude: ["virtualenv/"]
+  # Or as an alternative, you can use NFS mounts which are faster and auto-sync
+  # config.vm.synced_folder "../st2", "/home/vagrant/local/st2", type: "nfs", nfs_udp: false
 end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,11 +11,6 @@ Vagrant.configure("2") do |config|
     vb.cpus = 2
   end
 
-  config.vm.provision "shell", inline: <<-SHELL
-    sudo apt-get update
-    sudo apt-get -y install python python-setuptools
-  SHELL
-
   config.vm.provision "ansible_local" do |ansible|
     ansible.config_file = "/vagrant/ansible/ansible.cfg"
     ansible.playbook = "/vagrant/ansible/main.yml"

--- a/ansible/roles/st2_dev/tasks/system.yml
+++ b/ansible/roles/st2_dev/tasks/system.yml
@@ -26,3 +26,18 @@
     regexp: '^stanley'
     line: 'stanley ALL=(ALL) NOPASSWD: ALL'
     validate: 'visudo -cf %s'
+- name: Generate and add SSH key for stanley user for remote actions
+  become: true
+  ansible.builtin.shell: |
+    if [ -f "/home/stanley/.ssh/authorized_keys" ]; then
+      exit 0
+    fi
+
+    ssh-keygen -b 2048 -t rsa -f "/home/vagrant/.ssh/stanley_rsa" -q -N "" -m pem
+    mkdir -p /home/stanley/.ssh
+    chmod 660 /home/stanley/.ssh
+    chmod +x /home/stanley/.ssh
+    cp /home/vagrant/.ssh/stanley_rsa.pub /home/stanley/.ssh/authorized_keys
+    chmod 660 /home/stanley/.ssh/authorized_keys
+    chown -R stanley: /home/stanley/.ssh/
+    chown -R vagrant: /home/vagrant/.ssh/


### PR DESCRIPTION
This pull request updates ansible provisioner to also generate and configure ssh key for stanley user which can be used to run ``core.remote`` actions on localhost.

I just went with a quick inline shell script which is definitely not the best and most robust approach, but it works.