### PR TITLE
Add support for Python 3.8, Mongo DB 4.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,90 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    type: [opened, reopened, edited]
+    branches:
+      - master
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  # Special job which automatically cancels old runs for the same branch, prevents runs for the
+  # same file set which has already passed, etc.
+  pre_job:
+    name: Skip Duplicate Jobs Pre Job
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@4c656bbdb6906310fa6213604828008bc28fe55d # v3.3.0
+        with:
+          cancel_others: 'true'
+          github_token: ${{ github.token }}
+
+  vagrant-up:
+    needs: pre_job
+    # Need to run it on OSX since nested virtualization is not supported on Linux runners
+    runs-on: macos-10.15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: 'Python 3.6 + MongoDB 4.0'
+            python_version: "3.6"
+            mongodb_version: "4.0"
+          - name: 'Python 3.8 + MongoDB 4.4'
+            python_version: "3.8"
+            mongodb_version: "4.4"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache Vagrant boxes
+      uses: actions/cache@v2
+      with:
+        path: ~/.vagrant.d/boxes
+        key: ${{ runner.os }}-vagrant-ubuntu-bionic64
+        restore-keys: |
+          ${{ runner.os }}-vagrant-
+
+    - name: Clone StackStorm/st2 repo
+      run: |
+        git clone https://github.com/StackStorm/st2.git /tmp/st2
+
+    - name: Run vagrant up
+      #env:
+      #  ANSIBLE_DEBUG: "true"
+      run: |
+        sed -i".bak" -E -e "s#../st2#/tmp/st2#g" Vagrantfile
+        sed -i".bak" -E -e "s#3.6#${{ matrix.python_version }}#g" Vagrantfile
+        sed -i".bak" -E -e "s#4.0#${{ matrix.mongodb_version }}#g" Vagrantfile
+        cat Vagrantfile
+
+        vagrant up
+
+    # NOTE: vagrant ssh -c exists with the same exit code as command which is ran in the VM
+    - name: Verify Software Versions And Running Processes
+      run: |
+        vagrant ssh -c "python3 --version ; dpkg -l | grep mongodb-org"
+        vagrant ssh -c "python3 --version | grep ${{ matrix.python_version }}"
+        vagrant ssh -c "dpkg -l  | grep mongodb-org | grep ${{ matrix.mongodb_version }}"
+        vagrant ssh -c "ps aux | grep mongodb | grep -v grep"
+        vagrant ssh -c "ps aux | grep rabbitmq | grep -v grep"
+        vagrant ssh -c "sudo ls -la /home/stanley/.ssh"
+        vagrant ssh -c "sudo ls -la /home/vagrant/.ssh"
+        vagrant ssh -c "sudo ls -la /home/stanley/.ssh/authorized_keys"
+        vagrant ssh -c "sudo ls -la /home/vagrant/.ssh/stanley_rsa"
+
+    - name: Verify Create Virtualenv
+      run: |
+        # NOTE: To speed this step in theory we could use shared folder on host and cache
+        # ~/.cache/pip on guest
+        # Verify we can create virtualenv
+        vagrant ssh -c "cd ~/st2 ; make requirements"
+        # Verify we can run tests - NOTE: This will fail for 3.8 until StackStorm/st2 PR is merged
+        #vagrant ssh -c "cd st2 ; source virtualenv/bin/activate ; ./virtualenv/bin/nosetests -s -v st2api/tests/unit/controllers/v1/test_actions.py"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Stackstorm Vagrant Dev Environment
 
+[![Build Status](https://github.com/StackStorm/st2vagrantdev/actions/workflows/ci.yaml/badge.svg)](https://github.com/StackStorm/st2vagrantdev/actions/workflows/ci.yaml)
+
 NOTE: This repository is for people working on (developing) StackStorm. End users and people who just want
 to quickly try out and test StackStorm using Vagrant should use https://github.com/StackStorm/st2vagrant.
 
@@ -32,7 +34,8 @@ Note: Make sure to run step 5 (`make requirements`) inside `~/local/st2` instead
 ### Specifying a Python and MongoDB version
 
 By default, the image is provisioned using Python 3.6 and Mongo DB 4.0. If you want to us Python
-3.8 and MongoDB 4.4 you can do that editing corresponding variables in ``Vagrantfile``.
+3.8 and MongoDB 4.4 you can do that editing corresponding variables in ``Vagrantfile`` before
+running ``vagrant up`` / ``vagrant provision``.
 
 For example:
 
@@ -48,3 +51,10 @@ not supported.
 
 If you want to change the version or develop on multiple different versions, you should just create
 a new vagrant VM.
+
+If you want to enable ansible debug logging for the provision step, you can do that by setting
+``ANSIBLE_DEBUG`` environment variable as shown below.
+
+```bash
+ANSIBLE_DEBUG=1 vagrant provision
+```

--- a/README.md
+++ b/README.md
@@ -21,4 +21,17 @@ To quickly get bootstrapped run the following:
 You will likely from here want to share your local `st2` repo with the vagrant image to migrate code 
 more quickly. To sync your changes execute `vagrant rsync` from within this repo. `vagrant rsync` command 
 assumes that the local `st2` repo is accessible as `../st2`. 
+
 Note: Make sure to run step 5 (`make requirements`) inside `~/st2/local/st2` instead of `~/st2` to have the `PYTHONPATH` point to the modules inside `~/st2/local/st2`. 
+
+### Specifying a Python version
+
+By default, the image is provisioned using Python 3.6. If you want to use Python 3.8, you can do
+that by using the following command:
+
+```bash
+ST2_PYTHON_VERSION=3.8 vagrant up
+```
+
+Keep in mind that if you re-provision an existing VM with a different Python version, you will nee
+to remove ``~/st2/virtualenv`` directory and run ``make requirements`` again.

--- a/README.md
+++ b/README.md
@@ -32,14 +32,19 @@ Note: Make sure to run step 5 (`make requirements`) inside `~/local/st2` instead
 ### Specifying a Python and MongoDB version
 
 By default, the image is provisioned using Python 3.6 and Mongo DB 4.0. If you want to us Python
-3.8 and MongoDB 4.4 you can do that by using the following command:
+3.8 and MongoDB 4.4 you can do that editing corresponding variables in ``Vagrantfile``.
 
-```bash
-ST2_PYTHON_VERSION=3.8 ST2_MONGODB_VERSION=4.4 vagrant up
+For example:
+
+```ruby
+...
+PYTHON_VERSION = "3.8"
+MONGODB_VERSION = "4.4"
+...
 ```
 
-Keep in mind that if you re-provision an existing VM with a different Python version, you will nee
-to remove ``~/st2/virtualenv`` directory and run ``make requirements`` again.
+Keep in mind that re-provisioning an existing VM with a different version of Python or MongoDB is
+not supported.
 
-To avoid that and if you want to develop against multiple Python versions, you should just
-provision another vagrant VM with a different Python version.
+If you want to change the version or develop on multiple different versions, you should just create
+a new vagrant VM.

--- a/README.md
+++ b/README.md
@@ -24,14 +24,17 @@ assumes that the local `st2` repo is accessible as `../st2`.
 
 Note: Make sure to run step 5 (`make requirements`) inside `~/st2/local/st2` instead of `~/st2` to have the `PYTHONPATH` point to the modules inside `~/st2/local/st2`. 
 
-### Specifying a Python version
+### Specifying a Python and MongoDB version
 
-By default, the image is provisioned using Python 3.6. If you want to use Python 3.8, you can do
-that by using the following command:
+By default, the image is provisioned using Python 3.6 and Mongo DB 4.0. If you want to us Python
+3.8 and MongoDB 4.4 you can do that by using the following command:
 
 ```bash
-ST2_PYTHON_VERSION=3.8 vagrant up
+ST2_PYTHON_VERSION=3.8 ST2_MONGODB_VERSION=4.4 vagrant up
 ```
 
 Keep in mind that if you re-provision an existing VM with a different Python version, you will nee
 to remove ``~/st2/virtualenv`` directory and run ``make requirements`` again.
+
+To avoid that and if you want to develop against multiple Python versions, you should just
+provision another vagrant VM with a different Python version.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,11 @@
 #-*- mode: ruby -*-
 # vi: set ft=ruby :
 
+VM_NAME = "st2-dev-py-" + (ENV['ST2_PYTHON_VERSION'] || "3.6") + "-mongo-" + (ENV['ST2_MONGODB_VERSION'] || "4.0")
+
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
+  config.vm.hostname = VM_NAME
 
   config.vm.network "private_network", ip: "192.168.50.25"
   config.vm.network "forwarded_port", guest: 9101, host: 9101
@@ -12,8 +15,7 @@ Vagrant.configure("2") do |config|
     # Modify those as you see fit
     vb.memory = 4096
     vb.cpus = 2
-    vb.name = "st2-dev-py-" + (ENV['ST2_PYTHON_VERSION'] || "3.6")
-    vb.name = "st2-dev-py-" + (ENV['ST2_PYTHON_VERSION'] || "3.6") + "mongo-" + (ENV['ST2_MONGODB_VERSION'] || "4.0")
+    vb.name = VM_NAME
   end
 
   config.vm.provision "ansible_local" do |ansible|
@@ -21,6 +23,7 @@ Vagrant.configure("2") do |config|
     ansible.playbook = "/vagrant/ansible/main.yml"
     ansible.extra_vars = {
       python_version: ENV['ST2_PYTHON_VERSION'] || "3.6",
+      mongodb_version: ENV['ST2_MONGODB_VERSION'] || "4.0",
     }
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ MONGODB_VERSION = "4.0"
 VM_NAME = "st2-dev-py-" + PYTHON_VERSION + "-mongo-" + MONGODB_VERSION
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/bionic64"
   config.vm.hostname = VM_NAME
 
   config.vm.network "private_network", ip: "192.168.50.25"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,22 +5,27 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
 
   config.vm.network "private_network", ip: "192.168.50.25"
+  config.vm.network "forwarded_port", guest: 9101, host: 9101
+  config.vm.network "forwarded_port", guest: 9100, host: 9100
 
   config.vm.provider "virtualbox" do |vb|
+    # Modify those as you see fit
     vb.memory = 4096
     vb.cpus = 2
+    vb.name = "st2-dev-py-" + (ENV['ST2_PYTHON_VERSION'] || "3.6")
   end
-
-  config.vm.provision "shell", inline: <<-SHELL
-    sudo apt-get update
-    sudo apt-get -y install python python-setuptools
-  SHELL
 
   config.vm.provision "ansible_local" do |ansible|
     ansible.config_file = "/vagrant/ansible/ansible.cfg"
     ansible.playbook = "/vagrant/ansible/main.yml"
+    ansible.extra_vars = {
+      python_version: ENV['ST2_PYTHON_VERSION'] || "3.6",
+    }
   end
 
+  # config.vm.synced_folder "../st2", "/home/vagrant/local/st2", type: "rsync", rsync__exclude: ["virtualenv/"]
+  # Or as an alternative, you can use NFS mounts which are faster and auto-sync
+  #config.vm.synced_folder "../st2", "/home/vagrant/local/st2", type: "nfs", nfs_udp: false
   config.vm.synced_folder "../st2", "/home/vagrant/local/st2", type: "rsync", rsync__exclude: ["virtualenv/"]
 end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,9 +23,6 @@ Vagrant.configure("2") do |config|
     }
   end
 
-  # config.vm.synced_folder "../st2", "/home/vagrant/local/st2", type: "rsync", rsync__exclude: ["virtualenv/"]
-  # Or as an alternative, you can use NFS mounts which are faster and auto-sync
-  #config.vm.synced_folder "../st2", "/home/vagrant/local/st2", type: "nfs", nfs_udp: false
   config.vm.synced_folder "../st2", "/home/vagrant/local/st2", type: "rsync", rsync__exclude: ["virtualenv/"]
   # Or as an alternative, you can use NFS mounts which are faster and auto-sync
   # config.vm.synced_folder "../st2", "/home/vagrant/local/st2", type: "nfs", nfs_udp: false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,9 @@ PYTHON_VERSION = "3.6"
 # Valid values are 4.0 and 4.4
 MONGODB_VERSION = "4.0"
 
-VM_NAME = "st2-dev-py-" + PYTHON_VERSION + "-mongo-" + MONGODB_VERSION
+VM_NAME = "st2-dev-py-" + PYTHON_VERSION.sub( ".", "") + "-mongo-" + MONGODB_VERSION.sub(".", "")
+
+ANSIBLE_DEBUG = ENV.has_key?('ANSIBLE_DEBUG') ? "vvv" : ""
 
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/bionic64"
@@ -27,6 +29,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "ansible_local" do |ansible|
     ansible.config_file = "/vagrant/ansible/ansible.cfg"
     ansible.playbook = "/vagrant/ansible/main.yml"
+    ansible.verbose = ANSIBLE_DEBUG
     ansible.extra_vars = {
       python_version: PYTHON_VERSION,
       mongodb_version: MONGODB_VERSION,

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,7 @@ Vagrant.configure("2") do |config|
     vb.memory = 4096
     vb.cpus = 2
     vb.name = "st2-dev-py-" + (ENV['ST2_PYTHON_VERSION'] || "3.6")
+    vb.name = "st2-dev-py-" + (ENV['ST2_PYTHON_VERSION'] || "3.6") + "mongo-" + (ENV['ST2_MONGODB_VERSION'] || "4.0")
   end
 
   config.vm.provision "ansible_local" do |ansible|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,13 @@
 #-*- mode: ruby -*-
 # vi: set ft=ruby :
 
-VM_NAME = "st2-dev-py-" + (ENV['ST2_PYTHON_VERSION'] || "3.6") + "-mongo-" + (ENV['ST2_MONGODB_VERSION'] || "4.0")
+# Valid values are 3.6 and 3.8
+PYTHON_VERSION = "3.6"
+
+# Valid values are 4.0 and 4.4
+MONGODB_VERSION = "4.0"
+
+VM_NAME = "st2-dev-py-" + PYTHON_VERSION + "-mongo-" + MONGODB_VERSION
 
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
@@ -22,8 +28,8 @@ Vagrant.configure("2") do |config|
     ansible.config_file = "/vagrant/ansible/ansible.cfg"
     ansible.playbook = "/vagrant/ansible/main.yml"
     ansible.extra_vars = {
-      python_version: ENV['ST2_PYTHON_VERSION'] || "3.6",
-      mongodb_version: ENV['ST2_MONGODB_VERSION'] || "4.0",
+      python_version: PYTHON_VERSION,
+      mongodb_version: MONGODB_VERSION,
     }
   end
 

--- a/ansible/roles/st2_dev/tasks/mongo.yml
+++ b/ansible/roles/st2_dev/tasks/mongo.yml
@@ -2,18 +2,23 @@
 - name: Add mongo ppa key
   become: yes
   apt_key:
-    url: https://www.mongodb.org/static/pgp/server-4.0.asc
+    url: https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc
     state: present
 - name: Add mongo sources list
   become: yes
   copy:
     dest: /etc/apt/sources.list.d/mongodb.list
     content: >
-        deb https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.0 multiverse
+        deb https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/{{ mongodb_version }} multiverse
 - name: Install mongo
   become: yes
   apt:
-    name: mongodb-org
+    name:
+      - mongodb-org
+      - mongodb-org-server
+      - mongodb-org-shell
+      - mongodb-org-tools
+      - mongodb-org-mongos
     state: latest
     update_cache: yes
   notify:

--- a/ansible/roles/st2_dev/tasks/mongo.yml
+++ b/ansible/roles/st2_dev/tasks/mongo.yml
@@ -9,7 +9,7 @@
   copy:
     dest: /etc/apt/sources.list.d/mongodb.list
     content: >
-        deb https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/{{ mongodb_version }} multiverse
+        deb https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/{{ mongodb_version }} multiverse
 - name: Install mongo
   become: yes
   apt:

--- a/ansible/roles/st2_dev/tasks/python.yml
+++ b/ansible/roles/st2_dev/tasks/python.yml
@@ -26,5 +26,9 @@
 - name: Set python{{ python_version }} as default python 3
   become: true
   ansible.builtin.shell: |
-    sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python{{ python_version }} 1
-    sudo update-alternatives --set python3 /usr/bin/python{{ python_version }}
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python{{ python_version }} 1
+    update-alternatives --set python3 /usr/bin/python{{ python_version }}
+
+    # We change default python3 binary so we need a hack for apt to still work
+    cd  /usr/lib/python3/dist-packages
+    sudo cp apt_pkg.cpython-36m-x86_64-linux-gnu.so apt_pkg.so || true

--- a/ansible/roles/st2_dev/tasks/python.yml
+++ b/ansible/roles/st2_dev/tasks/python.yml
@@ -10,21 +10,21 @@
   apt:
     state: latest
     name:
-      - python3.6
-      - python3.6-dev
-      - python3.6-venv
+      - python{{ python_version }}
+      - python{{ python_version }}-dev
+      - python{{ python_version }}-venv
       # Needed for python ldap package
       - libsasl2-dev
       - libldap2-dev
       - libssl-dev
 - name: Install pip
   become: true
-  ansible.builtin.shell: curl https://bootstrap.pypa.io/get-pip.py | sudo python3.6
+  ansible.builtin.shell: curl https://bootstrap.pypa.io/get-pip.py | sudo python{{ python_version }}
 - name: Install virtualenv
   become: true
-  ansible.builtin.shell: python3.6 -m pip install virtualenv
-- name: Set python3.6 as default python 3
+  ansible.builtin.shell: python{{ python_version }} -m pip install virtualenv
+- name: Set python{{ python_version }} as default python 3
   become: true
   ansible.builtin.shell: |
-    sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
-    sudo update-alternatives --set python3 /usr/bin/python3.6
+    sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python{{ python_version }} 1
+    sudo update-alternatives --set python3 /usr/bin/python{{ python_version }}

--- a/ansible/roles/st2_dev/tasks/system.yml
+++ b/ansible/roles/st2_dev/tasks/system.yml
@@ -13,6 +13,7 @@
       - libyaml-dev
       - nodejs
       - npm
+      - shellcheck
 - name: Add stanley user
   become: true
   user:

--- a/ansible/roles/st2_dev/tasks/system.yml
+++ b/ansible/roles/st2_dev/tasks/system.yml
@@ -12,7 +12,6 @@
       - libxml2-dev
       - libyaml-dev
       - nodejs
-      - npm
       - shellcheck
 - name: Add stanley user
   become: true


### PR DESCRIPTION
This pull request updates Vagrant file and adds support for provisioning a VM with Python 3.8.

We default to Python 3.6, but user can select Python 3.8 by setting ``ST2_PYTHON_VERSION=3.8`` environment variable when running ``vagrant up`` / ``vagrant provision``.

In addition to that, it installs shellcheck tool which is needed for pre-commit hook.