### PR TITLE
Update ansible role to also install Redis 6.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,7 @@ jobs:
         vagrant ssh -c "dpkg -l  | grep mongodb-org | grep ${{ matrix.mongodb_version }}"
         vagrant ssh -c "ps aux | grep mongodb | grep -v grep"
         vagrant ssh -c "ps aux | grep rabbitmq | grep -v grep"
+        vagrant ssh -c "ps aux | grep redis-server | grep -v grep"
         vagrant ssh -c "sudo ls -la /home/stanley/.ssh"
         vagrant ssh -c "sudo ls -la /home/vagrant/.ssh"
         vagrant ssh -c "sudo ls -la /home/stanley/.ssh/authorized_keys"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
     # NOTE: vagrant ssh -c exists with the same exit code as command which is ran in the VM
     - name: Verify Software Versions And Running Processes
       run: |
-        vagrant ssh -c "python3 --version ; dpkg -l | grep mongodb-org"
+        vagrant ssh -c "python3 --version ; dpkg -l | grep mongodb-org ; dpkg -l | grep redis-server"
         vagrant ssh -c "python3 --version | grep ${{ matrix.python_version }}"
         vagrant ssh -c "dpkg -l  | grep mongodb-org | grep ${{ matrix.mongodb_version }}"
         vagrant ssh -c "ps aux | grep mongodb | grep -v grep"

--- a/README.md
+++ b/README.md
@@ -58,3 +58,12 @@ If you want to enable ansible debug logging for the provision step, you can do t
 ```bash
 ANSIBLE_DEBUG=1 vagrant provision
 ```
+
+### Installed Versions of Software
+
+Right now the following versions of software are installed during provisioning:
+
+* Python 3.6
+* MongoDB 4.0
+* Redis 6.0
+* Nginx 1.10

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -2,4 +2,3 @@
 - hosts: all
   roles:
     - st2_dev
-

--- a/ansible/roles/st2_dev/handlers/main.yml
+++ b/ansible/roles/st2_dev/handlers/main.yml
@@ -9,3 +9,8 @@
   systemd:
     name: nginx
     state: restarted
+- name: restart redis
+  become: yes
+  systemd:
+    name: redis-server
+    state: restarted

--- a/ansible/roles/st2_dev/tasks/main.yml
+++ b/ansible/roles/st2_dev/tasks/main.yml
@@ -2,5 +2,6 @@
 - include_tasks: system.yml
 - include_tasks: python.yml
 - include_tasks: mongo.yml
+- include_tasks: redis.yml
 - include_tasks: nginx.yml
 - include_tasks: repos.yml

--- a/ansible/roles/st2_dev/tasks/redis.yml
+++ b/ansible/roles/st2_dev/tasks/redis.yml
@@ -1,0 +1,21 @@
+---
+- name: Add source repository into sources list
+  become: true
+  ansible.builtin.apt_repository:
+    update_cache: true
+    repo: ppa:chris-lea/redis-server
+    state: present
+- name: Install apt package
+  become: yes
+  apt:
+    name:
+      - redis-server
+    state: latest
+    update_cache: yes
+  notify:
+      - restart redis
+- name: Enable Redis service
+  become: yes
+  systemd:
+    name: redis-server.service
+    enabled: yes


### PR DESCRIPTION
This PR updates Ansible role to also install Redis which is now used as a default coordination backend.