### PR TITLE
Install and use RabbitMQ server 3.8 (+ corresponding more recent version of Erlang)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,9 +70,11 @@ jobs:
     # NOTE: vagrant ssh -c exists with the same exit code as command which is ran in the VM
     - name: Verify Software Versions And Running Processes
       run: |
-        vagrant ssh -c "python3 --version ; dpkg -l | grep mongodb-org ; dpkg -l | grep redis-server"
+        vagrant ssh -c "python3 --version ; dpkg -l | grep mongodb-org ; dpkg -l | grep redis-server ; dpkg -l | grep erlang-base ; dpkg -l | grep rabbitmq-server"
         vagrant ssh -c "python3 --version | grep ${{ matrix.python_version }}"
         vagrant ssh -c "dpkg -l  | grep mongodb-org | grep ${{ matrix.mongodb_version }}"
+        vagrant ssh -c "dpkg -l  | grep erlang-base | grep 23.3"
+        vagrant ssh -c "dpkg -l  | grep rabbitmq-server | grep 3.8"
         vagrant ssh -c "ps aux | grep mongodb | grep -v grep"
         vagrant ssh -c "ps aux | grep rabbitmq | grep -v grep"
         vagrant ssh -c "ps aux | grep redis-server | grep -v grep"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ ANSIBLE_DEBUG=1 vagrant provision
 Right now the following versions of software are installed during provisioning:
 
 * Python 3.6
+* RabbitMQ 3.8
+* Erlang 1.23.3
 * MongoDB 4.0
 * Redis 6.0
 * Nginx 1.10

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,9 @@ PYTHON_VERSION = "3.6"
 # Valid values are 4.0 and 4.4
 MONGODB_VERSION = "4.0"
 
+ERLANG_VERSION = "1:23.3.1-1rmq1ppa1~ubuntu18.04.1"
+RABBITMQ_VERSION = "3.8.14-1"
+
 VM_NAME = "st2-dev-py-" + PYTHON_VERSION.sub( ".", "") + "-mongo-" + MONGODB_VERSION.sub(".", "")
 
 ANSIBLE_DEBUG = ENV.has_key?('ANSIBLE_DEBUG') ? "vvv" : ""
@@ -33,6 +36,8 @@ Vagrant.configure("2") do |config|
     ansible.extra_vars = {
       python_version: PYTHON_VERSION,
       mongodb_version: MONGODB_VERSION,
+      rabbitmq_version: RABBITMQ_VERSION,
+      erlang_version: ERLANG_VERSION,
     }
   end
 

--- a/ansible/roles/st2_dev/handlers/main.yml
+++ b/ansible/roles/st2_dev/handlers/main.yml
@@ -14,3 +14,8 @@
   systemd:
     name: redis-server
     state: restarted
+- name: restart rabbitmq-server
+  become: yes
+  systemd:
+    name: rabbitmq-server
+    state: restarted

--- a/ansible/roles/st2_dev/tasks/main.yml
+++ b/ansible/roles/st2_dev/tasks/main.yml
@@ -2,6 +2,7 @@
 - include_tasks: system.yml
 - include_tasks: python.yml
 - include_tasks: mongo.yml
+- include_tasks: rabbitmq.yml
 - include_tasks: redis.yml
 - include_tasks: nginx.yml
 - include_tasks: repos.yml

--- a/ansible/roles/st2_dev/tasks/rabbitmq.yml
+++ b/ansible/roles/st2_dev/tasks/rabbitmq.yml
@@ -1,0 +1,60 @@
+---
+- name: Add RabbitMQ erlang repo key
+  become: true
+  ansible.builtin.apt_key:
+    keyserver: keyserver.ubuntu.com
+    id: F77F1EDA57EBB1CC
+- name: Add RabbitMQ server repo key
+  become: yes
+  apt_key:
+    url: https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey
+    state: present
+- name: Add RabbitMQ Erlang apt repo list
+  become: yes
+  copy:
+    dest: /etc/apt/sources.list.d/rabbitmq-erlang.list
+    content: >
+        deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu bionic main
+- name: Add RabbitMQ server apt repo list
+  become: yes
+  copy:
+    dest: /etc/apt/sources.list.d/rabbitmq-server.list
+    content: >
+        deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ bionic main
+# This step is needed so correct latest versions of erlang packages get installed
+- name: Install Erlang
+  become: yes
+  apt:
+    name:
+      - erlang-base={{ erlang_version }}
+      - erlang-asn1={{ erlang_version }}
+      - erlang-crypto={{ erlang_version }}
+      - erlang-eldap={{ erlang_version }}
+      - erlang-ftp={{ erlang_version }}
+      - erlang-inets={{ erlang_version }}
+      - erlang-mnesia={{ erlang_version }}
+      - erlang-os-mon={{ erlang_version }}
+      - erlang-parsetools={{ erlang_version }}
+      - erlang-public-key={{ erlang_version }}
+      - erlang-runtime-tools={{ erlang_version }}
+      - erlang-snmp={{ erlang_version }}
+      - erlang-ssl={{ erlang_version }}
+      - erlang-syntax-tools={{ erlang_version }}
+      - erlang-tftp={{ erlang_version }}
+      - erlang-tools={{ erlang_version }}
+      - erlang-xmerl={{ erlang_version }}
+    state: present
+    update_cache: yes
+- name: Install RabbitMQ
+  become: yes
+  apt:
+    name:
+      - rabbitmq-server={{ rabbitmq_version }}
+    state: present
+    update_cache: yes
+  notify:
+      - restart rabbitmq-server
+- name: Enable rabbitmq-server service
+  become: yes
+  systemd:
+    name: rabbitmq-server.service

--- a/ansible/roles/st2_dev/tasks/system.yml
+++ b/ansible/roles/st2_dev/tasks/system.yml
@@ -4,10 +4,8 @@
   apt:
     state: latest
     name:
-      - rabbitmq-server
       - libffi-dev
       - libssl-dev
-      - rabbitmq-server
       - libxslt1-dev
       - libxml2-dev
       - libyaml-dev


### PR DESCRIPTION
This PR updates ansible provisioning code so specific more recent / latest version of RabbitMQ is installed (3.8) and also corresponding more recent version of Erlang (23.3.1) which is required for newer versions of RabbitMQ.

Previously many years old 3.5 version was installed which is available in default upstream Bionic repos.

This was it's in-line with recent changes made in other StackStorm repos by @amanda11.